### PR TITLE
kwargs in setup is its own var and not in self

### DIFF
--- a/acsadmin/views.py
+++ b/acsadmin/views.py
@@ -31,7 +31,7 @@ class AcsQueueJobCreate(CreateView):
     def setup(self, *args, **kwargs):
         self.acs_device = get_object_or_404(
             AcsDevice,
-            pk=self.kwargs['pk'],
+            pk=kwargs['pk'],
         )
 
     def form_valid(self, form):


### PR DESCRIPTION
In order to prevent kwargs key errors on AcsQueueJobCreate.
Kwargs is not in self but is passed as a parameter.